### PR TITLE
Fix queue insertion logic

### DIFF
--- a/src/providers/Player/utils/queue.ts
+++ b/src/providers/Player/utils/queue.ts
@@ -14,9 +14,11 @@ export function buildNewQueue(
 
 	let newQueue: JellifyTrack[] = []
 
-	if (_.isEmpty(existingQueue)) newQueue = tracksToInsert
-	else {
-		newQueue = _.cloneDeep(existingQueue).splice(insertIndex, 0, ...tracksToInsert)
+	if (_.isEmpty(existingQueue)) {
+		newQueue = tracksToInsert
+	} else {
+		newQueue = _.cloneDeep(existingQueue)
+		newQueue.splice(insertIndex, 0, ...tracksToInsert)
 	}
 
 	console.debug(`Built new queue of ${newQueue.length} items`)


### PR DESCRIPTION
## Summary
- fix buildNewQueue to return updated queue rather than splice result

## Testing
- `yarn lint`
- `yarn tsc`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_687c72a560d8832e8baca836a099d7a8